### PR TITLE
소셜 로그인 버그 수정(User, Admin 엔티티 생성자 수정)

### DIFF
--- a/src/main/kotlin/com/waffletoy/team1server/account/controller/UserController.kt
+++ b/src/main/kotlin/com/waffletoy/team1server/account/controller/UserController.kt
@@ -28,7 +28,7 @@ class UserController(
     }
 
     // 유저 이메일 인증 링크 클릭
-    @PostMapping("/verify-email")
+    @PostMapping("/signup/verify-email")
     fun verifyEmail(
         @RequestBody request: VerifyCodeRequest,
     ): ResponseEntity<Void> {

--- a/src/main/kotlin/com/waffletoy/team1server/account/persistence/AccountEntity.kt
+++ b/src/main/kotlin/com/waffletoy/team1server/account/persistence/AccountEntity.kt
@@ -17,7 +17,7 @@ open class AccountEntity(
     @Id
     @Column(name = "id", nullable = false, updatable = false, length = 36)
     open val id: String = UUID.randomUUID().toString(),
-    @Column(name = "username", nullable = false, unique = true)
+    @Column(name = "username", nullable = false)
     open var username: String,
     @Column(name = "local_id", unique = true)
     open var localId: String? = null,
@@ -36,3 +36,4 @@ open class AccountEntity(
 // password, username 등의 naming 모호함 issue-> 나중에
 // username -> User를 일반 유저로 한정지은 순간 username이라는 Naming이 모호해짐.
 // username nullable 해야 하지 않나? 아니면 나방129 등으로 자동생성해주는 library라도 불러와야.
+// username은 겹칠 수 있음(동명이인)

--- a/src/main/kotlin/com/waffletoy/team1server/account/persistence/AdminEntity.kt
+++ b/src/main/kotlin/com/waffletoy/team1server/account/persistence/AdminEntity.kt
@@ -7,9 +7,9 @@ import jakarta.persistence.*
 class AdminEntity(
     @Column(name = "profile_image_link", length = 255)
     var profileImageLink: String? = null,
-    override var username: String,
-    override var password: String? = null,
-    override var localId: String? = null,
+    username: String,
+    password: String? = null,
+    localId: String? = null,
 //    @OneToMany(mappedBy = "admin", cascade = [CascadeType.ALL], orphanRemoval = true)
 //    val posts: List<PostEntity> = mutableListOf()
 ) : AccountEntity(

--- a/src/main/kotlin/com/waffletoy/team1server/account/persistence/UserEntity.kt
+++ b/src/main/kotlin/com/waffletoy/team1server/account/persistence/UserEntity.kt
@@ -11,9 +11,9 @@ class UserEntity(
     var googleId: String? = null,
     @Column(name = "phone_number", nullable = true)
     var phoneNumber: String? = null,
-    override var username: String,
-    override var localId: String? = null,
-    override var password: String? = null,
+    username: String,
+    localId: String? = null,
+    password: String? = null,
     // @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL], orphanRemoval = true)
     // val posts: List<PostEntity> = mutableListOf()
 ) : AccountEntity(
@@ -21,3 +21,4 @@ class UserEntity(
         localId = localId,
         password = password,
     )
+// 부모의 생성자로 넘어가는 변수는 정의하지 않음

--- a/src/main/kotlin/com/waffletoy/team1server/account/service/UserService.kt
+++ b/src/main/kotlin/com/waffletoy/team1server/account/service/UserService.kt
@@ -120,6 +120,13 @@ class UserService(
                 ),
             )
 
+        if (user.username == null) {
+            throw UserServiceException(
+                "user.username is Null",
+                HttpStatus.BAD_REQUEST,
+            )
+        }
+
         // 토큰 발급 및 저장
         val tokens = issueTokens(user)
         return Pair(User.fromEntity(user), tokens)


### PR DESCRIPTION
### 📝 작업 내용

- User, Admin 엔티티 생성자 수정
- Account(부모 클래스)에 넘겨주는 인자는 초기화나 override 없이 인자 그대로 넘겨주어야 합니다.

### 📸 스크린샷 (선택)

### 🚀 리뷰 요구사항 (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
