### PR TITLE
/user/me 구현

### DIFF
--- a/src/main/kotlin/com/waffletoy/team1server/resume/controller/Resume.kt
+++ b/src/main/kotlin/com/waffletoy/team1server/resume/controller/Resume.kt
@@ -19,7 +19,7 @@ data class Resume(
         ): Resume =
             Resume(
                 id = resumeEntity.id,
-                postId = resumeEntity.role?.id,
+                postId = resumeEntity.position?.id,
                 author = if (includeAuthor) User.fromEntity(resumeEntity.user, includeResumes = false) else null,
                 content = resumeEntity.content ?: "",
                 createdAt = resumeEntity.createdAt,

--- a/src/main/kotlin/com/waffletoy/team1server/user/controller/UserController.kt
+++ b/src/main/kotlin/com/waffletoy/team1server/user/controller/UserController.kt
@@ -111,9 +111,14 @@ class UserController(
         userService.checkSnuMailVerification(request) // TODO: 뭐라도 Return해야 하지는 않을지
         return ResponseEntity.ok().build()
     }
+
     // TODO
-    // @GetMapping("/me")
-    // fun getUserInfo()
+    @GetMapping("/me")
+    fun getUserInfo(
+        @Parameter(hidden = true) @AuthUser user: User,
+    ): ResponseEntity<User> {
+        return ResponseEntity.ok(user)
+    }
 
     // Endpoint for resetting DB for testing
 


### PR DESCRIPTION
### 📝 작업 내용

- /user/me를 구현합니다. - AuthUser로 얻은 UserDTO를 그대로 반환
- UserDTO에서 프론트에 필요한 정보(id, name, snuMail, phonenumber, profileImageLink)만을 넘기는 UserBrief와 같은 DTO 추가가 필요합니다.

### 📸 스크린샷 (선택)

### 🚀 리뷰 요구사항 (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
