### PR TITLE
Refc/#102/endermaru - Post, Resume 서비스 점검

### DIFF
--- a/src/main/kotlin/com/waffletoy/team1server/exceptions/ApiException.kt
+++ b/src/main/kotlin/com/waffletoy/team1server/exceptions/ApiException.kt
@@ -110,3 +110,8 @@ class S3SDKClientFailedException(details: Map<String, Any>? = null) : ApiExcepti
     errorCode = ErrorCode.POST_S3_SDK_FAILED,
     details = details,
 )
+
+class UserNotAuthorizedException(details: Map<String, Any>? = null) : ApiException(
+    errorCode = ErrorCode.USER_INVALID_ROLE,
+    details = details,
+)

--- a/src/main/kotlin/com/waffletoy/team1server/exceptions/ApiException.kt
+++ b/src/main/kotlin/com/waffletoy/team1server/exceptions/ApiException.kt
@@ -100,3 +100,13 @@ class InvalidRequestException(details: Map<String, Any>? = null) : ApiException(
     errorCode = ErrorCode.INVALID_REQUEST,
     details = details,
 )
+
+class S3UrlGenerationFailedException(details: Map<String, Any>? = null) : ApiException(
+    errorCode = ErrorCode.POST_S3_URL_GENERATION_FAILED,
+    details = details,
+)
+
+class S3SDKClientFailedException(details: Map<String, Any>? = null) : ApiException(
+    errorCode = ErrorCode.POST_S3_SDK_FAILED,
+    details = details,
+)

--- a/src/main/kotlin/com/waffletoy/team1server/exceptions/ErrorCode.kt
+++ b/src/main/kotlin/com/waffletoy/team1server/exceptions/ErrorCode.kt
@@ -47,6 +47,8 @@ enum class ErrorCode(
     POST_COMPANY_EXISTS("POST_007", "Company email already exists", HttpStatus.CONFLICT),
     POST_COMPANY_NOT_FOUND("POST_008", "Company not found.", HttpStatus.NOT_FOUND),
     POST_ACCESS_FORBIDDEN("POST_009", "Access to this company forbidden.", HttpStatus.FORBIDDEN),
+    POST_S3_URL_GENERATION_FAILED("POST_010", "S3 URL generation failed.", HttpStatus.INTERNAL_SERVER_ERROR),
+    POST_S3_SDK_FAILED("POST_011", "AWS SKD Client error", HttpStatus.INTERNAL_SERVER_ERROR),
 
     // Resume-related errors
     RESUME_NOT_FOUND("RESUME_001", "The requested resume was not found.", HttpStatus.NOT_FOUND),

--- a/src/main/kotlin/com/waffletoy/team1server/post/controller/PostController.kt
+++ b/src/main/kotlin/com/waffletoy/team1server/post/controller/PostController.kt
@@ -104,17 +104,19 @@ class PostController(
     // s3 bucket
     @PostMapping("/upload/presigned")
     fun generateUploadPresignedUrl(
+        @Parameter(hidden = true) @AuthUser user: User,
         @RequestBody preSignedUploadReq: PreSignedUploadReq,
     ): ResponseEntity<PresignedURL> {
-        val presignedUrl = s3Service.generateUploadPreSignUrl(preSignedUploadReq, bucketName)
+        val presignedUrl = s3Service.generateUploadPreSignUrl(user, preSignedUploadReq, bucketName)
         return ResponseEntity.ok(PresignedURL(presignedUrl))
     }
 
     @PostMapping("/download/presigned")
     fun generateDownloadPresignedUrl(
+        @Parameter(hidden = true) @AuthUser user: User,
         @RequestBody preSignedDownloadReq: PreSignedDownloadReq,
     ): ResponseEntity<PresignedURL> {
-        val presignedUrl = s3Service.generateDownloadPreSignUrl(preSignedDownloadReq, bucketName)
+        val presignedUrl = s3Service.generateDownloadPreSignUrl(user, preSignedDownloadReq, bucketName)
         return ResponseEntity.ok(PresignedURL(presignedUrl))
     }
 

--- a/src/main/kotlin/com/waffletoy/team1server/post/controller/PostController.kt
+++ b/src/main/kotlin/com/waffletoy/team1server/post/controller/PostController.kt
@@ -11,7 +11,6 @@ import jakarta.validation.Valid
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
@@ -123,22 +122,23 @@ class PostController(
     @PostMapping("/dev/make-dummy")
     fun makeDummyPost(
         @RequestBody cnt: Int,
+        @RequestBody pw: PasswordRequest,
     ): ResponseEntity<Void> {
-        postService.makeDummyPosts(cnt)
+        postService.makeDummyPosts(cnt, pw.pw)
         return ResponseEntity.ok().build()
     }
 
-    @PostMapping("/dev/reset-db")
-    fun resetDBPosts(
-        @RequestBody pw: PasswordRequest,
-    ): ResponseEntity<Void> {
-        if (pw.pw == "0000") {
-            postService.resetDB(pw.pw)
-            return ResponseEntity.ok().build()
-        } else {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
-        }
-    }
+//    @PostMapping("/dev/reset-db")
+//    fun resetDBPosts(
+//        @RequestBody pw: PasswordRequest,
+//    ): ResponseEntity<Void> {
+//        if (pw.pw == "0000") {
+//            postService.resetDB(pw.pw)
+//            return ResponseEntity.ok().build()
+//        } else {
+//            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+//        }
+//    }
 
     @PostMapping("/company")
     fun createCompany(

--- a/src/main/kotlin/com/waffletoy/team1server/post/service/PostService.kt
+++ b/src/main/kotlin/com/waffletoy/team1server/post/service/PostService.kt
@@ -62,6 +62,7 @@ class PostService(
      * @param investmentMin Minimum investment amount.
      * @param status Status filter (e.g., active, inactive).
      * @param series List of series names to filter by.
+     * @param order sort posts by newest(0) or employmentEndDate(1)
      * @param page The page number to retrieve.
      * @return A paginated [Page] of [Post].
      * @throws PostInvalidFiltersException If invalid filters are provided.
@@ -202,7 +203,16 @@ class PostService(
      * @param cnt The number of dummy posts to create.
      */
     @Transactional
-    fun makeDummyPosts(cnt: Int) {
+    fun makeDummyPosts(
+        cnt: Int,
+        secret: String,
+    ) {
+        if (secret != devSecret) {
+            throw InvalidRequestException(
+                details = mapOf("providedSecret" to secret),
+            )
+        }
+
         val companies = mutableListOf<CompanyEntity>()
         val positions = mutableListOf<PositionEntity>()
 
@@ -249,20 +259,20 @@ class PostService(
         positionRepository.saveAll(positions)
     }
 
-    /**
-     * Resets the database by deleting all companies, bookmarks, and positions.
-     */
-    @Transactional
-    fun resetDB(secret: String) {
-        if (secret != resetDbSecret) {
-            throw InvalidRequestException(
-                details = mapOf("providedSecret" to secret),
-            )
-        }
-        companyRepository.deleteAll()
-        bookmarkRepository.deleteAll()
-        positionRepository.deleteAll()
-    }
+//    /**
+//     * Resets the database by deleting all companies, bookmarks, and positions.
+//     */
+//    @Transactional
+//    fun resetDB(secret: String) {
+//        if (secret != resetDbSecret) {
+//            throw InvalidRequestException(
+//                details = mapOf("providedSecret" to secret),
+//            )
+//        }
+//        companyRepository.deleteAll()
+//        bookmarkRepository.deleteAll()
+//        positionRepository.deleteAll()
+//    }
 
     fun getUserEntityOrThrow(userId: String): UserEntity =
         userService.getUserEntityByUserId(userId) ?: throw UserNotFoundException(mapOf("userId" to userId))
@@ -379,5 +389,5 @@ class PostService(
     }
 
     @Value("\${custom.SECRET}")
-    private lateinit var resetDbSecret: String
+    private lateinit var devSecret: String
 }

--- a/src/main/kotlin/com/waffletoy/team1server/post/service/S3Service.kt
+++ b/src/main/kotlin/com/waffletoy/team1server/post/service/S3Service.kt
@@ -6,7 +6,7 @@ import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.AmazonS3Exception
 import com.waffletoy.team1server.exceptions.S3SDKClientFailedException
 import com.waffletoy.team1server.exceptions.S3UrlGenerationFailedException
-import com.waffletoy.team1server.exceptions.UserRoleConflictException
+import com.waffletoy.team1server.exceptions.UserNotAuthorizedException
 import com.waffletoy.team1server.post.controller.PreSignedDownloadReq
 import com.waffletoy.team1server.post.controller.PreSignedUploadReq
 import com.waffletoy.team1server.user.UserRole
@@ -29,7 +29,7 @@ class S3Service(
         expirationMinutes: Long = EXPIRATION_MINUTES,
     ): String {
         if (user.userRole != UserRole.CURATOR) {
-            throw UserRoleConflictException()
+            throw UserNotAuthorizedException()
         }
         try {
             val filePath = "${preSignedUploadReq.fileName}.${preSignedUploadReq.fileType}"
@@ -49,7 +49,7 @@ class S3Service(
         expirationMinutes: Long = EXPIRATION_MINUTES,
     ): String {
         if (user.userRole != UserRole.CURATOR) {
-            throw UserRoleConflictException()
+            throw UserNotAuthorizedException()
         }
         try {
             val expiration = calculateExpiration(expirationMinutes)

--- a/src/main/kotlin/com/waffletoy/team1server/resume/controller/Resume.kt
+++ b/src/main/kotlin/com/waffletoy/team1server/resume/controller/Resume.kt
@@ -8,7 +8,7 @@ data class Resume(
     val id: String,
     val positionTitle: String? = null,
     val companyName: String? = null,
-    val author: User?,
+    val author: User,
     val content: String,
     val phoneNumber: String,
     val createdAt: LocalDateTime,


### PR DESCRIPTION
### 📝 작업 내용

- S3 Service의 예외처리 추가
- Post : make-dummy에 비밀번호 추가(Custom.secret)
- resetDB 삭제
- 회원가입, 로그인, 토큰 재발급 시 redis refresh token 저장 로직 추가
- 커피챗 취소 -> 삭제로 기능 변경(이메일 기반이므로 취소 불가)

### 📸 스크린샷 (선택)

### 🚀 리뷰 요구사항 (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
