### PR TITLE
Refc/#106/endermaru - S3 Link를 FileInfo로 변경

### DIFF
--- a/src/main/kotlin/com/waffletoy/team1server/post/controller/PostController.kt
+++ b/src/main/kotlin/com/waffletoy/team1server/post/controller/PostController.kt
@@ -123,10 +123,9 @@ class PostController(
     // dev
     @PostMapping("/dev/make-dummy")
     fun makeDummyPost(
-        @RequestBody cnt: Int,
         @RequestBody pw: PasswordRequest,
     ): ResponseEntity<Void> {
-        postService.makeDummyPosts(cnt, pw.pw)
+        postService.makeDummyPosts(pw.cnt, pw.pw)
         return ResponseEntity.ok().build()
     }
 
@@ -184,4 +183,7 @@ data class PresignedURL(
     val presignedUrl: String,
 )
 
-data class PasswordRequest(val pw: String)
+data class PasswordRequest(
+    val cnt: Int,
+    val pw: String,
+)

--- a/src/main/kotlin/com/waffletoy/team1server/post/dto/AuthorBrief.kt
+++ b/src/main/kotlin/com/waffletoy/team1server/post/dto/AuthorBrief.kt
@@ -3,5 +3,5 @@ package com.waffletoy.team1server.post.dto
 data class AuthorBrief(
     val id: String,
     val name: String,
-    val profileImageLink: String?,
+    val profileImageLink: FileInfo,
 )

--- a/src/main/kotlin/com/waffletoy/team1server/post/dto/Company.kt
+++ b/src/main/kotlin/com/waffletoy/team1server/post/dto/Company.kt
@@ -14,8 +14,8 @@ class Company(
     // Defaults to 0 if not provided
     val investAmount: Int? = null,
     val investCompany: String? = null,
-    val imageLink: String? = null,
-    val irDeckLink: String? = null,
+    val imageLink: FileInfo,
+    val irDeckLink: FileInfo,
     val landingPageLink: String? = null,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime,
@@ -35,8 +35,16 @@ class Company(
                 // Optional field
                 investAmount = entity.investAmount.takeIf { it > 0 },
                 investCompany = entity.investCompany,
-                imageLink = entity.imageLink,
-                irDeckLink = entity.irDeckLink,
+                imageLink =
+                    FileInfo(
+                        entity.imageFileName ?: "",
+                        entity.imageFileType ?: "",
+                    ),
+                irDeckLink =
+                    FileInfo(
+                        entity.irDeckFileName ?: "",
+                        entity.irDeckFileType ?: "",
+                    ),
                 landingPageLink = entity.landingPageLink,
                 createdAt = entity.createdAt,
                 updatedAt = entity.updatedAt,

--- a/src/main/kotlin/com/waffletoy/team1server/post/dto/CreateCompanyRequest.kt
+++ b/src/main/kotlin/com/waffletoy/team1server/post/dto/CreateCompanyRequest.kt
@@ -20,10 +20,10 @@ data class CreateCompanyRequest(
     @field:Min(value = 0, message = "Invest amount must be non-negative.")
     val investAmount: Int? = null,
     val investCompany: String? = null,
-    @field:URL(message = "Image link must be a valid URL.")
-    val imageLink: String? = null,
-    @field:URL(message = "IR deck link must be a valid URL.")
-    val irDeckLink: String? = null,
+//    @field:URL(message = "Image link must be a valid URL.")
+    val imageLink: FileInfo,
+//    @field:URL(message = "IR deck link must be a valid URL.")
+    val irDeckLink: FileInfo,
     @field:URL(message = "Landing page link must be a valid URL.")
     val landingPageLink: String? = null,
     @field:Valid

--- a/src/main/kotlin/com/waffletoy/team1server/post/dto/FileInfo.kt
+++ b/src/main/kotlin/com/waffletoy/team1server/post/dto/FileInfo.kt
@@ -1,0 +1,6 @@
+package com.waffletoy.team1server.post.dto
+
+data class FileInfo(
+    val fileName: String?,
+    val fileType: String?,
+)

--- a/src/main/kotlin/com/waffletoy/team1server/post/dto/Post.kt
+++ b/src/main/kotlin/com/waffletoy/team1server/post/dto/Post.kt
@@ -45,7 +45,11 @@ data class Post(
                     AuthorBrief(
                         id = entity.company.admin.id,
                         name = entity.company.admin.name,
-                        profileImageLink = entity.company.admin.profileImageLink,
+                        profileImageLink =
+                            FileInfo(
+                                entity.company.admin.profileImageFileName,
+                                entity.company.admin.profileImageFileInfo,
+                            ),
                     ),
                 companyName = entity.company.companyName,
                 explanation = entity.company.explanation ?: "",

--- a/src/main/kotlin/com/waffletoy/team1server/post/dto/Post.kt
+++ b/src/main/kotlin/com/waffletoy/team1server/post/dto/Post.kt
@@ -17,9 +17,9 @@ data class Post(
     val investAmount: Int,
     val investCompany: String,
     val series: Series,
-    val irDeckLink: String,
+    val irDeckLink: FileInfo,
     val landingPageLink: String,
-    val imageLink: String,
+    val imageLink: FileInfo,
     val externalDescriptionLink: List<Link>,
     val tags: List<String>,
     // 직군 정보
@@ -54,9 +54,17 @@ data class Post(
                 investAmount = entity.company.investAmount,
                 investCompany = entity.company.investCompany ?: "",
                 series = entity.company.series,
-                irDeckLink = entity.company.irDeckLink ?: "",
+                irDeckLink =
+                    FileInfo(
+                        entity.company.irDeckFileName ?: "",
+                        entity.company.irDeckFileType ?: "",
+                    ),
                 landingPageLink = entity.company.landingPageLink ?: "",
-                imageLink = entity.company.imageLink ?: "",
+                imageLink =
+                    FileInfo(
+                        entity.company.imageFileName ?: "",
+                        entity.company.imageFileType ?: "",
+                    ),
                 externalDescriptionLink = entity.company.links.map { Link.fromVo(it) },
                 tags = entity.company.tags.map { it.tag },
                 // roles 정보

--- a/src/main/kotlin/com/waffletoy/team1server/post/dto/PostBrief.kt
+++ b/src/main/kotlin/com/waffletoy/team1server/post/dto/PostBrief.kt
@@ -13,7 +13,7 @@ data class PostBrief(
     val investAmount: Int,
     val investCompany: String,
     val series: Series,
-    val imageLink: String,
+    val imageLink: FileInfo,
     val title: String,
     val employmentEndDate: LocalDateTime?,
     val createdAt: LocalDateTime,

--- a/src/main/kotlin/com/waffletoy/team1server/post/persistence/CompanyEntity.kt
+++ b/src/main/kotlin/com/waffletoy/team1server/post/persistence/CompanyEntity.kt
@@ -36,10 +36,14 @@ class CompanyEntity(
     @Enumerated(EnumType.STRING)
     @Column(name = "SERIES", nullable = false)
     open var series: Series = Series.SEED,
-    @Column(name = "IMAGE_LINK", length = 2048)
-    open var imageLink: String? = null,
-    @Column(name = "IR_DECK_LINK", length = 2048)
-    open var irDeckLink: String? = null,
+    @Column(name = "IMAGE_FILE_NAME")
+    open var imageFileName: String? = null,
+    @Column(name = "IMAGE_FILE_TYPE")
+    open var imageFileType: String? = null,
+    @Column(name = "IR_DECK_FILE_NAME")
+    open var irDeckFileName: String? = null,
+    @Column(name = "IR_DECK_FILE_TYPE")
+    open var irDeckFileType: String? = null,
     @Column(name = "LANDING_PAGE_LINK", length = 2048)
     open var landingPageLink: String? = null,
     @CreatedDate

--- a/src/main/kotlin/com/waffletoy/team1server/post/service/PostService.kt
+++ b/src/main/kotlin/com/waffletoy/team1server/post/service/PostService.kt
@@ -235,7 +235,8 @@ class PostService(
                     investAmount = (1000..5000).random(),
                     investCompany = "Company A$index, Company B$index",
                     series = Series.entries.random(),
-                    imageLink = "https://www.company$index/image",
+                    imageFileName = "linkName of dummy $index",
+                    imageFileType = "png",
                     tags = tags,
                 )
             companies.add(companyEntity)
@@ -329,8 +330,10 @@ class PostService(
                 slogan = request.slogan,
                 investAmount = request.investAmount ?: 0,
                 investCompany = request.investCompany,
-                imageLink = request.imageLink,
-                irDeckLink = request.irDeckLink,
+                imageFileName = request.imageLink.fileName,
+                imageFileType = request.imageLink.fileType,
+                irDeckFileName = request.irDeckLink.fileName,
+                irDeckFileType = request.irDeckLink.fileType,
                 landingPageLink = request.landingPageLink,
                 links = request.links.map { LinkVo(description = it.description, link = it.link) }.toMutableList(),
                 tags = request.tags.map { TagVo(tag = it.tag) }.toMutableList(),

--- a/src/main/kotlin/com/waffletoy/team1server/user/dtos/User.kt
+++ b/src/main/kotlin/com/waffletoy/team1server/user/dtos/User.kt
@@ -1,5 +1,6 @@
 package com.waffletoy.team1server.user.dtos
 
+import com.waffletoy.team1server.post.dto.FileInfo
 import com.waffletoy.team1server.user.UserRole
 import com.waffletoy.team1server.user.persistence.UserEntity
 import java.time.LocalDateTime
@@ -14,7 +15,7 @@ data class User(
     val phoneNumber: String?,
 //    val resumes: List<Resume>?,
 //    val posts: List<Post>?,
-    val profileImageLink: String?,
+    val profileImageLink: FileInfo,
     val isMerged: Boolean,
 ) {
     companion object {
@@ -33,7 +34,11 @@ data class User(
                 phoneNumber = entity.phoneNumber,
 //                resumes = if (includeResumes) entity.resumes.map { Resume.fromEntity(it, false) } else null,
 //                posts = entity.posts.map { Post.fromEntity(it.roles) },
-                profileImageLink = entity.profileImageLink,
+                profileImageLink =
+                    FileInfo(
+                        entity.profileImageFileName,
+                        entity.profileImageFileInfo,
+                    ),
                 isMerged = isMerged,
             )
     }

--- a/src/main/kotlin/com/waffletoy/team1server/user/persistence/UserEntity.kt
+++ b/src/main/kotlin/com/waffletoy/team1server/user/persistence/UserEntity.kt
@@ -49,8 +49,10 @@ class UserEntity(
     // 역시 Position Entity에서 조회할 예정
 //    @OneToMany(mappedBy = "admin")
 //    var posts: MutableList<CompanyEntity> = mutableListOf(),
-    @Column(name = "profile_image_link", nullable = true, length = 2048)
-    val profileImageLink: String? = null,
+    @Column(name = "profile_image_file_name", nullable = true)
+    val profileImageFileName: String? = null,
+    @Column(name = "profile_image_file_info", nullable = true)
+    val profileImageFileInfo: String? = null,
 ) {
     // Validates either local or google login is provided
     @PrePersist


### PR DESCRIPTION
### 📝 작업 내용

- S3에 업로드되는 파일 정보를 url 대신 fileName, fileType의 두 필드로 각각 저장합니다.(irdeck, image, profileimage)
- DTO에는 string 대신 FileInfo{fileName, fileType}로 수정했습니다.
- createCompany, makeDummy에도 해당 변경 내용 반영했습니다.

### 📸 스크린샷 (선택)

### 🚀 리뷰 요구사항 (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
