### PR TITLE
javamailsender - MimeMessageHelper + Thymeleaf

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,6 +67,9 @@ dependencies {
     implementation("org.jsoup:jsoup:1.18.3")
 
     implementation("com.amazonaws:aws-java-sdk:1.12.779")
+
+    // thymeleaf
+    implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
 }
 
 allOpen {

--- a/src/main/kotlin/com/waffletoy/team1server/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/waffletoy/team1server/auth/service/AuthService.kt
@@ -9,6 +9,7 @@ import com.waffletoy.team1server.auth.utils.PasswordGenerator
 import com.waffletoy.team1server.auth.utils.UserTokenUtil
 import com.waffletoy.team1server.coffeeChat.service.CoffeeChatService
 import com.waffletoy.team1server.email.EmailSendFailureException
+import com.waffletoy.team1server.email.EmailType
 import com.waffletoy.team1server.email.service.EmailService
 import com.waffletoy.team1server.exceptions.*
 import com.waffletoy.team1server.post.service.PostService
@@ -202,9 +203,10 @@ class AuthService(
         authRedisCacheService.saveEmailCode(request.snuMail, encryptedEmailCode)
         try {
             emailService.sendEmail(
+                type = EmailType.VerifyMail,
                 to = request.snuMail,
                 subject = "[인턴하샤] 이메일 인증 요청 메일이 도착했습니다.",
-                text = "이메일 인증 번호: $emailCode",
+                text = emailCode,
             )
         } catch (ex: Exception) {
             throw EmailSendFailureException(
@@ -297,13 +299,10 @@ class AuthService(
         // 로컬 계정 유저의 정보를 제공 or 소셜 로그인 정보를 제공
         try {
             emailService.sendEmail(
+                type = EmailType.ResetPassword,
                 to = user.mail,
                 subject = "[인턴하샤] 임시 비밀번호를 알려드립니다.",
-                text =
-                    """
-                    다음 임시 비밀번호를 이용하여 로그인 후 비밀번호를 재설정하세요.
-                    - 임시 비밀번호 : $newPassword
-                    """.trimIndent(),
+                text = newPassword,
             )
         } catch (ex: Exception) {
             throw EmailSendFailureException(

--- a/src/main/kotlin/com/waffletoy/team1server/email/EmailType.kt
+++ b/src/main/kotlin/com/waffletoy/team1server/email/EmailType.kt
@@ -1,0 +1,6 @@
+package com.waffletoy.team1server.email
+
+enum class EmailType {
+    ResetPassword,
+    VerifyMail,
+}

--- a/src/main/kotlin/com/waffletoy/team1server/email/service/EmailService.kt
+++ b/src/main/kotlin/com/waffletoy/team1server/email/service/EmailService.kt
@@ -1,26 +1,52 @@
 package com.waffletoy.team1server.email.service
 
 import com.waffletoy.team1server.email.EmailSendFailureException
-import org.springframework.mail.SimpleMailMessage
+import com.waffletoy.team1server.email.EmailType
 import org.springframework.mail.javamail.JavaMailSender
+import org.springframework.mail.javamail.MimeMessageHelper
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
+import org.thymeleaf.context.Context
+import org.thymeleaf.spring6.SpringTemplateEngine
 
 @Service
 class EmailService(
     private val mailSender: JavaMailSender,
+    private val templateEngine: SpringTemplateEngine,
 ) {
     @Async
     fun sendEmail(
+        type: EmailType,
         to: String,
         subject: String,
         text: String,
     ) {
         try {
-            val message = SimpleMailMessage()
-            message.setTo(to)
-            message.setSubject(subject)
-            message.setText(text)
+            val message = mailSender.createMimeMessage()
+            val helper = MimeMessageHelper(message, true, "UTF-8")
+            val context = Context()
+
+            val templateName: String
+
+            when (type) {
+                EmailType.VerifyMail -> {
+                    context.setVariable("emailCode", text)
+                    templateName = "verifyEmail"
+                }
+                EmailType.ResetPassword -> {
+                    context.setVariable("newPassword", text)
+                    templateName = "resetPassword"
+                }
+            }
+
+            // Thymeleaf 템플릿
+            val content: String = templateEngine.process(templateName, context)
+
+            // 이메일 정보 설정
+            helper.setTo(to)
+            helper.setSubject(subject)
+            helper.setText(content, true)
+
             mailSender.send(message)
         } catch (ex: Exception) {
             throw EmailSendFailureException()

--- a/src/main/resources/templates/resetPassword.html
+++ b/src/main/resources/templates/resetPassword.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en"
+    xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+    <body style="font-family: Arial, sans-serif; line-height: 1.6; padding: 20px; background-color: #f9f9f9;">
+        <div style="max-width: 500px; margin: 0 auto; background-color: #ffffff; padding: 20px;
+                        border-radius: 8px; border: 1px solid #ddd;">
+            <p style="font-size: 16px; font-weight: bold; color: #333;">
+                다음 임시 비밀번호를 이용하여 로그인 후 비밀번호를 재설정하세요.
+            </p>
+            <pre th:text="${newPassword}" style="background-color: #eee; padding: 10px; border-radius: 5px;
+                            font-size: 16px; font-weight: bold; white-space: pre-wrap;
+                            word-break: break-word; text-align: left;">
+                    placeholder
+            </pre>
+        </div>
+    </body>
+</html>

--- a/src/main/resources/templates/verifyEmail.html
+++ b/src/main/resources/templates/verifyEmail.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en"
+    xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+    <body style="font-family: Arial, sans-serif; line-height: 1.6; padding: 20px; background-color: #f9f9f9;">
+        <div style="max-width: 500px; margin: 0 auto; background-color: #ffffff; padding: 20px;
+                        border-radius: 8px; border: 1px solid #ddd;">
+            <p style="font-size: 16px; font-weight: bold; color: #333;">
+                이메일 인증 번호를 입력해주세요.
+            </p>
+            <pre th:text="${emailCode}" style="background-color: #eee; padding: 10px; border-radius: 5px;
+                            font-size: 16px; font-weight: bold; white-space: pre-wrap;
+                            word-break: break-word; text-align: left;">
+                    placeholder
+            </pre>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
### 📝 작업 내용

- JavaMailSender에 html 형식으로 보낼 수 있도록 MimeMessageHelper + Thymeleaf 사용
- 이메일 인증 메일, 비밀변경 메일에 대한 Thymeleaf 템플릿 추가(스타일 적용 가능)
- '&'을 plain text로 표현
- close #141 

### 📸 스크린샷 (선택)
![image.png](attachment:2ced5484-e393-487d-9065-1fa6dc33950b:image.png)

### 🚀 리뷰 요구사항 (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
