### PR TITLE
JSOUP 필터링 수정

### DIFF
--- a/src/main/kotlin/com/waffletoy/team1server/config/InputSanitizationAspect.kt
+++ b/src/main/kotlin/com/waffletoy/team1server/config/InputSanitizationAspect.kt
@@ -4,6 +4,7 @@ import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation.*
 import org.aspectj.lang.annotation.Around
 import org.jsoup.Jsoup
+import org.jsoup.nodes.Document.OutputSettings
 import org.jsoup.safety.Safelist
 import org.springframework.stereotype.Component
 import kotlin.reflect.full.memberProperties
@@ -21,7 +22,7 @@ class InputSanitizationAspect {
     private fun sanitize(obj: Any?): Any? {
         return when (obj) {
             // 문자열 필터링
-            is String -> Jsoup.clean(obj, Safelist.basic())
+            is String -> Jsoup.clean(obj, "", Safelist.none(), OutputSettings().prettyPrint(false))
             // 리스트 내부 요소 필터링
             is List<*> -> obj.map { sanitize(it) }
             // Map 내부 값 필터링
@@ -41,7 +42,7 @@ class InputSanitizationAspect {
                 field.isAccessible = true
                 val value = field.get(obj) as? String
                 if (value != null) {
-                    field.set(obj, Jsoup.clean(value, Safelist.basic()))
+                    field.set(obj, Jsoup.clean(value, "", Safelist.none(), OutputSettings().prettyPrint(false)))
                 }
             }
         return obj

--- a/src/test/resources/Me.http
+++ b/src/test/resources/Me.http
@@ -105,7 +105,7 @@ Authorization: Bearer {{access_token_company2}}
   "headcount": 150,
   "location": "Seoul, South Korea",
   "slogan": "Innovating the Future",
-  "detail": "We are a cutting-edge tech company specializing in AI and software solutions.",
+  "detail": "We are a cutting-edge tech comp\nany specializing in AI and software solutions.",
   "profileImageKey": "profile-image-key-123",
   "companyInfoPDFLink": "https://example.com/company-info.pdf",
   "landingPageLink": "https://example.com",


### PR DESCRIPTION
### 📝 작업 내용
Jsoup.clean(value, Safelist.basic()) : HTML에서 허용된 태그 외에는 모두 제거하고, 그 과정에서 공백 문자나 줄바꿈 문자도 같이 삭제 & 공백으로 치환함
-> Jsoup.clean(value, "", Safelist.none(), OutputSettings().prettyPrint(false)) 으로 HTML 태그는 제외하되, 나머지 공백을 수정하지 않고, 자동 들여쓰기도 비활성화

close #195 

### 📸 스크린샷 (선택)

### 🚀 리뷰 요구사항 (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
